### PR TITLE
Add Binance minute data fetcher example

### DIFF
--- a/Algorithm.Python/BinanceMinuteData.py
+++ b/Algorithm.Python/BinanceMinuteData.py
@@ -1,0 +1,64 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Simple helper script to fetch 1-minute BTCUSDT data from Binance.
+The script queries Binance's public REST API every minute and prints the
+latest open, high, low, close and volume values.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+from typing import Any, Dict
+
+
+def fetch_latest_kline(symbol: str = "BTCUSDT") -> Dict[str, Any] | None:
+    """Fetch the latest kline for the given symbol from Binance."""
+    url = (
+        f"https://api.binance.com/api/v3/klines?symbol={symbol}&interval=1m&limit=1"
+    )
+    with urllib.request.urlopen(url) as response:
+        data = json.loads(response.read().decode("utf-8"))
+
+    if not data:
+        return None
+
+    k = data[0]
+    return {
+        "open_time": k[0],
+        "open": float(k[1]),
+        "high": float(k[2]),
+        "low": float(k[3]),
+        "close": float(k[4]),
+        "volume": float(k[5]),
+        "close_time": k[6],
+    }
+
+
+def main() -> None:
+    """Continuously fetch and display the latest BTCUSDT minute kline."""
+    while True:
+        kline = fetch_latest_kline()
+        if kline is not None:
+            print(
+                f"Time: {kline['open_time']} Open: {kline['open']} Close: {kline['close']} Volume: {kline['volume']}"
+            )
+        else:
+            print("No data returned from Binance")
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/Python/binance_fetch_minute_test.py
+++ b/Tests/Python/binance_fetch_minute_test.py
@@ -1,0 +1,27 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+
+# Ensure Algorithm.Python is on the path
+sys.path.insert(0, 'Algorithm.Python')
+import BinanceMinuteData as module
+
+
+class BinanceMinuteDataTest(unittest.TestCase):
+    @patch('urllib.request.urlopen')
+    def test_fetch_latest_kline(self, mock_urlopen):
+        sample = [[1, '100', '110', '90', '105', '15', 2]]
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(sample).encode('utf-8')
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+        data = module.fetch_latest_kline('BTCUSDT')
+        self.assertEqual(data['open'], 100.0)
+        self.assertEqual(data['close'], 105.0)
+        self.assertEqual(data['volume'], 15.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add BinanceMinuteData.py script to fetch latest BTCUSDT candle
- add unit test for the script

## Testing
- `python3 Tests/Python/binance_fetch_minute_test.py`

------
https://chatgpt.com/codex/tasks/task_e_684bbf68345c83319fa9ced16a15335e