### PR TITLE
Add CCXT BigQuery downloader and tests

### DIFF
--- a/Tests/Python/ccxt_gcp_downloader_tests.py
+++ b/Tests/Python/ccxt_gcp_downloader_tests.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Ensure project root is on the path so Toolbox modules can be imported
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+# Provide a minimal ccxt stub before importing the downloader
+class _CcxtStub:
+    exchanges = []
+
+sys.modules.setdefault('ccxt', _CcxtStub())
+
+# Insert a minimal google.cloud.bigquery stub so the module can be imported
+import types
+_bq_module = types.ModuleType('bigquery')
+_bq_module.Client = object
+_cloud_module = types.ModuleType('cloud')
+_cloud_module.bigquery = _bq_module
+_google_module = types.ModuleType('google')
+_google_module.cloud = _cloud_module
+sys.modules.setdefault('google', _google_module)
+sys.modules.setdefault('google.cloud', _cloud_module)
+sys.modules.setdefault('google.cloud.bigquery', _bq_module)
+
+from ToolBox.CcxtDataDownloader import ccxt_gcp_downloader as downloader
+
+
+class BigQueryClientStub:
+    def __init__(self):
+        self.rows = []
+
+    def insert_rows_json(self, table_ref, rows):
+        self.rows.append((table_ref, rows))
+        return []
+
+
+class CcxtGcpDownloaderTests(unittest.TestCase):
+    def test_data_inserted_for_each_exchange(self):
+        dataset = 'ds'
+        table = 'tbl'
+        os.environ['BQ_DATASET'] = dataset
+        os.environ['BQ_TABLE'] = table
+
+        stub_client = BigQueryClientStub()
+        exchanges = ['binance', 'kraken']
+
+        with patch('ToolBox.CcxtDataDownloader.ccxt_gcp_downloader.bigquery.Client', return_value=stub_client):
+            with patch('ToolBox.CcxtDataDownloader.ccxt_gcp_downloader.ccxt.exchanges', exchanges):
+                with patch('ToolBox.CcxtDataDownloader.ccxt_gcp_downloader.fetch_exchange_data', side_effect=lambda ex: [{'id': ex}]):
+                    downloader.fetch_and_store_all_exchanges()
+
+        self.assertEqual(len(stub_client.rows), len(exchanges))
+        os.environ.pop('BQ_DATASET')
+        os.environ.pop('BQ_TABLE')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ToolBox/CcxtDataDownloader/ccxt_gcp_downloader.py
+++ b/ToolBox/CcxtDataDownloader/ccxt_gcp_downloader.py
@@ -1,0 +1,57 @@
+"""CCXT data downloader with optional BigQuery storage.
+
+This module fetches data from all supported CCXT exchanges. When the
+``BQ_DATASET`` and ``BQ_TABLE`` environment variables are defined the
+downloaded data will be inserted into the provided Google BigQuery
+table using :class:`google.cloud.bigquery.Client`.
+
+Environment variables
+---------------------
+BQ_DATASET : str
+    Destination BigQuery dataset id.
+BQ_TABLE : str
+    Destination BigQuery table id within the dataset.
+"""
+
+import os
+import ccxt
+from google.cloud import bigquery
+
+
+def fetch_exchange_data(exchange_id):
+    """Fetch data for a single exchange. This is a small wrapper around
+    ``ccxt``. The returned data must be serialisable as JSON.
+    """
+    exchange = getattr(ccxt, exchange_id)()
+    return exchange.fetch_markets()
+
+
+def store_to_bigquery(dataset_id, table_id, data):
+    """Store ``data`` into the given BigQuery dataset/table.
+
+    Parameters
+    ----------
+    dataset_id : str
+        BigQuery dataset id.
+    table_id : str
+        BigQuery table id.
+    data : Sequence[Mapping]
+        Iterable of rows to insert.
+    """
+    client = bigquery.Client()
+    table_ref = f"{dataset_id}.{table_id}"
+    errors = client.insert_rows_json(table_ref, data)
+    if errors:
+        raise RuntimeError(f"Failed to insert rows: {errors}")
+
+
+def fetch_and_store_all_exchanges():
+    """Fetch data for all ccxt exchanges and optionally store it in BigQuery."""
+    dataset = os.getenv("BQ_DATASET")
+    table = os.getenv("BQ_TABLE")
+
+    for exchange_id in ccxt.exchanges:
+        data = fetch_exchange_data(exchange_id)
+        if dataset and table:
+            store_to_bigquery(dataset, table, data)
+


### PR DESCRIPTION
## Summary
- add `ccxt_gcp_downloader` with BigQuery storage support
- document BQ environment vars
- add unit test covering BigQuery insertion logic

## Testing
- `pytest Tests/Python/ccxt_gcp_downloader_tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1e8c2e488331a4f032ffe0085d26